### PR TITLE
id in pre_get_shortlink can be zero

### DIFF
--- a/inc/class-better-yourls-actions.php
+++ b/inc/class-better-yourls-actions.php
@@ -221,7 +221,7 @@ class Better_YOURLS_Actions {
 		}
 
 		//If we've already created a shortlink return it or just return the default
-		$link = get_post_meta( $id, '_better_yourls_short_link', true );
+		$link = get_post_meta( $post->ID, '_better_yourls_short_link', true );
 
 		if ( $link == '' ) {
 			return $short_link;


### PR DESCRIPTION
$id in function pre_get_shortlink is 0 if it's called for the current blog post so the id needs to come from the post instead. Otherwise wordpress will not serve the youlrs url in the shortlink meta tag and http header.
