### PR TITLE
[WIP] Fix scheduled posts not having nice urls

### DIFF
--- a/classes/class-better-yourls-actions.php
+++ b/classes/class-better-yourls-actions.php
@@ -329,15 +329,17 @@ class Better_YOURLS_Actions {
 			$yourls_url = esc_url_raw( 'http' . $https . '://' . $this->settings['domain'] . '/yourls-api.php' );
 			$timestamp  = current_time( 'timestamp' );
 
+			list( $permalink, $post_name ) = get_sample_permalink( $post_id );
+
 			$args = array(
-					'body' => array(
-						'title'     => ( '' === trim( $title ) ) ? get_the_title( $post_id ) : $title,
-						'timestamp' => $timestamp,
-						'signature' => md5( $timestamp . $this->settings['key'] ),
-						'action'    => 'shorturl',
-						'url'       => get_permalink( $post_id ),
-						'format'    => 'JSON',
-					),
+				'body' => array(
+					'title'     => ( '' === trim( $title ) ) ? get_the_title( $post_id ) : $title,
+					'timestamp' => $timestamp,
+					'signature' => md5( $timestamp . $this->settings['key'] ),
+					'action'    => 'shorturl',
+					'url'       => str_replace( array( '%pagename%', '%postname%' ), $post_name, $permalink ),
+					'format'    => 'JSON',
+				),
 			);
 
 			// Keyword and title aren't currently used but may be in the future.


### PR DESCRIPTION
When calling `get_permalink` on a post with the status `future` the permalink is the preview url (`http://site.com?id=123456`), this is undesirable behaviour since this looks bad and causes another redirect.

This happens for some Twitter plugins for example, they create the tweet before the post is published so `wp_get_shortlink()` is called while the post is still scheduled.

However this "fix" probably only works when using the post name permalink setting I wanted to show it here to discuss fixes we can do to make this behave better.
