### PR TITLE
Fix for Security Error when using Bulk Edit

### DIFF
--- a/includes/class-better-yourls-actions.php
+++ b/includes/class-better-yourls-actions.php
@@ -103,6 +103,12 @@ class Better_YOURLS_Actions {
 			return false;
 		}
 
+		// Prevent save when using edit
+		global $pagenow;
+		if ($pagenow == 'edit.php' ) {
+			return false;
+		}
+
 		/**
 		 * Filter Better YOURLs post statuses
 		 *


### PR DESCRIPTION
Issue #19.
Adds line to return false on `_check_valid_post` function.
This prevents the 'Security Error' from appearing whenever using the build edit action.